### PR TITLE
Fix popout windows, cache BrowserWindowProxy

### DIFF
--- a/src/core/patchers/BrowserWindowPatcher.ts
+++ b/src/core/patchers/BrowserWindowPatcher.ts
@@ -9,19 +9,27 @@ export type PatchFunction = (
 ) => object;
 export type UnpatchFunction = () => boolean;
 
+declare type KernelWebContents = electron.WebContents & {
+	kernelWindowData?: {
+		originalPreload: string;
+		windowOptions: electron.BrowserViewConstructorOptions;
+	}
+}
+
 export const patches: {
 	[id: string]: PatchFunction;
 } = {};
 
 export const originalBrowserWindow = electron.BrowserWindow;
 
+let BrowserWindowProxy = null;
 const preloadPath = path.join(__dirname, "..", "..", "preload");
 
 patchElectron("BrowserWindow", (target, property) => {
 	if (property === "BrowserWindow") {
 		// Create a Proxy over Electron that returns the PatchedBrowserWindow if BrowserWindow is called.
 		// Can't just proxy the BrowserWindow class directly because it's a getter.
-		return new Proxy(target.BrowserWindow, {
+		BrowserWindowProxy ??= new Proxy(target.BrowserWindow, {
 			construct(BrowserWindowTarget, args) {
 				const [options, ...rest] = args;
 
@@ -52,7 +60,7 @@ patchElectron("BrowserWindow", (target, property) => {
 
 				// Put the location and the original preload in a place the main IPC can easily reach.
 				// @ts-ignore
-				window.webContents.kernelWindowData = {
+				(window.webContents as KernelWebContents).kernelWindowData = {
 					originalPreload: originalPreload,
 					windowOptions: options,
 				};
@@ -60,6 +68,8 @@ patchElectron("BrowserWindow", (target, property) => {
 				return window;
 			},
 		});
+
+		return BrowserWindowProxy;
 	}
 });
 

--- a/src/core/patchers/BrowserWindowPatcher.ts
+++ b/src/core/patchers/BrowserWindowPatcher.ts
@@ -59,7 +59,6 @@ patchElectron("BrowserWindow", (target, property) => {
 				const window = new BrowserWindowTarget(options, ...rest);
 
 				// Put the location and the original preload in a place the main IPC can easily reach.
-				// @ts-ignore
 				(window.webContents as KernelWebContents).kernelWindowData = {
 					originalPreload: originalPreload,
 					windowOptions: options,

--- a/src/core/utils/getWebPreference.ts
+++ b/src/core/utils/getWebPreference.ts
@@ -1,0 +1,11 @@
+const webFrame = (process as any)._linkedBinding("electron_renderer_web_frame");
+
+let getWebPreference = (id: string) => null;
+
+if (typeof webFrame.getWebPreference === "function") {
+    getWebPreference = (id: string) => webFrame.getWebPreference(window, id);
+} else if (typeof webFrame.mainFrame?.getWebPreference === "function") {
+    getWebPreference = (id: string) => webFrame.mainFrame.getWebPreference(id);
+}
+ 
+export default getWebPreference;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,7 @@ import path from "path";
 import injectRendererModule from "#kernel/core/utils/injectRendererModule";
 import * as packageLoader from "#kernel/core/packageLoader";
 import Logger from "#kernel/core/Logger";
+import getWebPreference from "#kernel/core/utils/getWebPreference";
 
 ipcRenderer.sendSync("KERNEL_SETUP_RENDERER_HOOK");
 
@@ -12,7 +13,10 @@ ipcRenderer.sendSync("KERNEL_SETUP_RENDERER_HOOK");
 const preloadData = ipcRenderer.sendSync("KERNEL_WINDOW_DATA");
 
 // If context isolation is off, this should be patched to make sure everything complies.
-if (!preloadData.windowOptions.webPreferences.contextIsolation) {
+const hasContextIsolation = getWebPreference("contextIsolation");
+
+Logger.log("ContextIsolation:", hasContextIsolation);
+if (!hasContextIsolation) {
 	contextBridge.exposeInMainWorld = function (key, value) {
 		window[key] = value;
 	};
@@ -29,7 +33,7 @@ injectRendererModule({
 	sync: true,
 });
 
-if (preloadData.originalPreload) {
+if (preloadData?.originalPreload) {
 	Logger.log("Running original preload:", preloadData.originalPreload);
 	require(preloadData.originalPreload);
 }


### PR DESCRIPTION
Fixes kernel failing to inject into windows opened by `window.open`. Unfortunately I couldn't find a way to access the `windowOptions`  to restore `kernelWindowData` on the webContents of those windows, but I added a workaround using a electron internal API. I also added a cache for the `BrowserWindowProxy` so it won't be re-created each time.